### PR TITLE
adding PlaneGeometry

### DIFF
--- a/src/ElementDescriptorContainer.js
+++ b/src/ElementDescriptorContainer.js
@@ -32,6 +32,7 @@ import BoxGeometryDescriptor from './descriptors/Geometry/BoxGeometryDescriptor'
 import SphereGeometryDescriptor from './descriptors/Geometry/SphereGeometryDescriptor';
 import ParametricGeometryDescriptor from './descriptors/Geometry/ParametricGeometryDescriptor';
 import PlaneBufferGeometryDescriptor from './descriptors/Geometry/PlaneBufferGeometryDescriptor';
+import PlaneGeometryDescriptor from './descriptors/Geometry/PlaneGeometryDescriptor';
 import PolyhedronGeometryDescriptor from './descriptors/Geometry/PolyhedronGeometryDescriptor';
 import IcosahedronGeometryDescriptor from './descriptors/Geometry/IcosahedronGeometryDescriptor';
 import OctahedronGeometryDescriptor from './descriptors/Geometry/OctahedronGeometryDescriptor';
@@ -118,6 +119,7 @@ class ElementDescriptorContainer {
       sphereGeometry: new SphereGeometryDescriptor(react3RendererInstance),
       parametricGeometry: new ParametricGeometryDescriptor(react3RendererInstance),
       planeBufferGeometry: new PlaneBufferGeometryDescriptor(react3RendererInstance),
+      planeGeometry: new PlaneGeometryDescriptor(react3RendererInstance),
       polyhedronGeometry: new PolyhedronGeometryDescriptor(react3RendererInstance),
       icosahedronGeometry: new IcosahedronGeometryDescriptor(react3RendererInstance),
       octahedronGeometry: new OctahedronGeometryDescriptor(react3RendererInstance),

--- a/src/descriptors/Geometry/PlaneGeometryDescriptor.js
+++ b/src/descriptors/Geometry/PlaneGeometryDescriptor.js
@@ -1,0 +1,45 @@
+import THREE from 'three.js';
+import GeometryDescriptorBase from './GeometryDescriptorBase';
+
+import PropTypes from 'react/lib/ReactPropTypes';
+
+class PlaneGeometryDescriptor extends GeometryDescriptorBase {
+  constructor(react3RendererInstance) {
+    super(react3RendererInstance);
+
+    [
+      'width',
+      'height'
+    ].forEach(propName => {
+      this.hasProp(propName, {
+        type: PropTypes.number.isRequired,
+        update: this.triggerRemount,
+        default: undefined,
+      });
+    });
+
+    [
+      'widthSegments',
+      'heightSegments'
+    ].forEach(propName => {
+      this.hasProp(propName, {
+        type: PropTypes.number,
+        update: this.triggerRemount,
+        default: undefined,
+      });
+    });
+  }
+
+  construct(props) {
+    const {
+      width,
+      height,
+      widthSegments,
+      heightSegments
+      } = props;
+
+    return new THREE.PlaneGeometry(width, height, widthSegments, heightSegments);
+  }
+}
+
+export default PlaneGeometryDescriptor;


### PR DESCRIPTION
It seems PlaneBufferGeometry is deprecated in Three (can't find it in the docs, at least). This pull adds a descriptor for PlaneGeometry.

Relevant link: http://threejs.org/docs/#Reference/Extras.Geometries/PlaneGeometry