### PR TITLE
Switching three.js repo to three to fix build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Installation
 ============
 
 ```
-npm install --save react react-dom three.js
+npm install --save react react-dom three
 npm install --save react-three-renderer
 ```
 
@@ -45,7 +45,7 @@ Here's a simple example that implements the [getting started scene for three.js]
 ```js
 import React from 'react';
 import React3 from 'react-three-renderer';
-import THREE from 'three.js';
+import THREE from 'three';
 import ReactDOM from 'react-dom';
 
 class Simple extends React.Component {

--- a/docs/src/Generator.js
+++ b/docs/src/Generator.js
@@ -654,7 +654,7 @@ export default (done) => {
   GLOBAL.HTMLCanvasElement = class HTMLCanvasElement {
   };
 
-  const THREE = require('three.js');
+  const THREE = require('three');
 
   Object.keys(THREE).forEach(key => {
     const value = THREE[key];

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "fbjs": "^0.4.0",
     "react": "^0.14.1",
     "react-dom": "^0.14.1",
-    "three.js": "^0.73.0"
+    "three": "^0.73.0"
   },
   "devDependencies": {
     "fbjs": ">=0.4.0",
     "react": ">=0.14.1",
     "react-dom": ">=0.14.1",
-    "three.js": ">=0.73.0",
+    "three": ">=0.73.0",
     "babel-core": "^5.8.29",
     "babel-eslint": "^4.1.3",
     "babel-runtime": "^5.8.29",

--- a/src/Module.js
+++ b/src/Module.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 class React3Module {
   constructor() {

--- a/src/React3.js
+++ b/src/React3.js
@@ -2,7 +2,7 @@ import React from 'react';
 import React3Renderer from './React3Renderer';
 import PureRenderMixin from 'react/lib/ReactComponentWithPureRenderMixin';
 
-import THREE from 'three.js';
+import THREE from 'three';
 
 const {PropTypes} = React;
 

--- a/src/React3Instance.js
+++ b/src/React3Instance.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 import Viewport from './Viewport';

--- a/src/React3Renderer.js
+++ b/src/React3Renderer.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import ReactEmptyComponent from 'react/lib/ReactEmptyComponent';
 import ReactElement from 'react/lib/ReactElement';

--- a/src/Resources/ResourceContainer.js
+++ b/src/Resources/ResourceContainer.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 class ResourceContainer extends THREE.Object3D {
   constructor() {

--- a/src/Resources/ResourceReference.js
+++ b/src/Resources/ResourceReference.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 class ResourceReference {
   constructor(resourceId) {

--- a/src/Shapes/AbsArcAction.js
+++ b/src/Shapes/AbsArcAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/Shapes/AbsEllipseAction.js
+++ b/src/Shapes/AbsEllipseAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/Shapes/BezierCurveToAction.js
+++ b/src/Shapes/BezierCurveToAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/Shapes/HoleAction.js
+++ b/src/Shapes/HoleAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/Shapes/LineToAction.js
+++ b/src/Shapes/LineToAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/Shapes/MoveToAction.js
+++ b/src/Shapes/MoveToAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/Shapes/QuadraticCurveToAction.js
+++ b/src/Shapes/QuadraticCurveToAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/Shapes/ShapeAction.js
+++ b/src/Shapes/ShapeAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 /**
  * @abstract

--- a/src/Shapes/SplineThruAction.js
+++ b/src/Shapes/SplineThruAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/Uniform.js
+++ b/src/Uniform.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 class Uniform {
   constructor() {

--- a/src/UniformContainer.js
+++ b/src/UniformContainer.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 class UniformContainer {
   constructor() {

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 class Viewport {
   constructor(props) {

--- a/src/descriptors/Geometry/BoxGeometryDescriptor.js
+++ b/src/descriptors/Geometry/BoxGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/CircleBufferGeometryDescriptor.js
+++ b/src/descriptors/Geometry/CircleBufferGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import BufferGeometryDescriptorBase from './BufferGeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/CircleGeometryDescriptor.js
+++ b/src/descriptors/Geometry/CircleGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/CylinderGeometryDescriptor.js
+++ b/src/descriptors/Geometry/CylinderGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/EdgesGeometryDescriptor.js
+++ b/src/descriptors/Geometry/EdgesGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import BufferGeometryDescriptorBase from './BufferGeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/ExtrudeGeometryDescriptor.js
+++ b/src/descriptors/Geometry/ExtrudeGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 import ShapeResourceReference from '../../Resources/ShapeResourceReference';
 

--- a/src/descriptors/Geometry/GeometryDescriptor.js
+++ b/src/descriptors/Geometry/GeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/GeometryDescriptorBase.js
+++ b/src/descriptors/Geometry/GeometryDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import THREEElementDescriptor from '../THREEElementDescriptor';
 
 import invariant from 'fbjs/lib/invariant';

--- a/src/descriptors/Geometry/IcosahedronGeometryDescriptor.js
+++ b/src/descriptors/Geometry/IcosahedronGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import PolyhedronGeometryDescriptorBase from './PolyhedronGeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/LatheGeometryDescriptor.js
+++ b/src/descriptors/Geometry/LatheGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/OctahedronGeometryDescriptor.js
+++ b/src/descriptors/Geometry/OctahedronGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import PolyhedronGeometryDescriptorBase from './PolyhedronGeometryDescriptorBase';
 
 class OctahedronGeometryDescriptor extends PolyhedronGeometryDescriptorBase {

--- a/src/descriptors/Geometry/ParametricGeometryDescriptor.js
+++ b/src/descriptors/Geometry/ParametricGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/PlaneBufferGeometryDescriptor.js
+++ b/src/descriptors/Geometry/PlaneBufferGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import BufferGeometryDescriptorBase from './BufferGeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/PlaneGeometryDescriptor.js
+++ b/src/descriptors/Geometry/PlaneGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/PolyhedronGeometryDescriptor.js
+++ b/src/descriptors/Geometry/PolyhedronGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import PolyhedronGeometryDescriptorBase from './PolyhedronGeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/PolyhedronGeometryDescriptorBase.js
+++ b/src/descriptors/Geometry/PolyhedronGeometryDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/RingGeometryDescriptor.js
+++ b/src/descriptors/Geometry/RingGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/Shapes/HoleDescriptor.js
+++ b/src/descriptors/Geometry/Shapes/HoleDescriptor.js
@@ -4,7 +4,7 @@ import HoleAction from '../../../Shapes/HoleAction';
 
 import invariant from 'fbjs/lib/invariant';
 
-import THREE from 'three.js';
+import THREE from 'three';
 
 class HoleDescriptor extends PathDescriptorBase {
   construct() {

--- a/src/descriptors/Geometry/Shapes/MoveToDescriptor.js
+++ b/src/descriptors/Geometry/Shapes/MoveToDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import ShapeActionDescriptorBase from './ShapeActionDescriptorBase';
 

--- a/src/descriptors/Geometry/Shapes/PathDescriptorBase.js
+++ b/src/descriptors/Geometry/Shapes/PathDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import THREEElementDescriptor from '../../THREEElementDescriptor';
 
 import invariant from 'fbjs/lib/invariant';

--- a/src/descriptors/Geometry/Shapes/ShapeActionDescriptorBase.js
+++ b/src/descriptors/Geometry/Shapes/ShapeActionDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import THREEElementDescriptor from '../../THREEElementDescriptor';
 
 import invariant from 'fbjs/lib/invariant';

--- a/src/descriptors/Geometry/Shapes/ShapeDescriptor.js
+++ b/src/descriptors/Geometry/Shapes/ShapeDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import PathDescriptorBase from './PathDescriptorBase';
 

--- a/src/descriptors/Geometry/Shapes/SplineThruDescriptor.js
+++ b/src/descriptors/Geometry/Shapes/SplineThruDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import ShapeActionDescriptorBase from './ShapeActionDescriptorBase';
 

--- a/src/descriptors/Geometry/SphereGeometryDescriptor.js
+++ b/src/descriptors/Geometry/SphereGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import BufferGeometryDescriptorBase from './BufferGeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/TetrahedronGeometryDescriptor.js
+++ b/src/descriptors/Geometry/TetrahedronGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import PolyhedronGeometryDescriptorBase from './PolyhedronGeometryDescriptorBase';
 
 class TetrahedronGeometryDescriptor extends PolyhedronGeometryDescriptorBase {

--- a/src/descriptors/Geometry/TorusGeometryDescriptor.js
+++ b/src/descriptors/Geometry/TorusGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Geometry/TorusKnotGeometryDescriptor.js
+++ b/src/descriptors/Geometry/TorusKnotGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import GeometryDescriptorBase from './GeometryDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Light/AmbientLightDescriptor.js
+++ b/src/descriptors/Light/AmbientLightDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import LightDescriptorBase from './LightDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Light/DirectionalLightDescriptor.js
+++ b/src/descriptors/Light/DirectionalLightDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import LightDescriptorBase from './LightDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Light/LightDescriptorBase.js
+++ b/src/descriptors/Light/LightDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import Object3DDescriptor from '../Object/Object3DDescriptor';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Light/PointLightDescriptor.js
+++ b/src/descriptors/Light/PointLightDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import LightDescriptorBase from './LightDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Light/SpotLightDescriptor.js
+++ b/src/descriptors/Light/SpotLightDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import LightDescriptorBase from './LightDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Material/LineBasicMaterialDescriptor.js
+++ b/src/descriptors/Material/LineBasicMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Material/LineDashedMaterialDescriptor.js
+++ b/src/descriptors/Material/LineDashedMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Material/MaterialDescriptorBase.js
+++ b/src/descriptors/Material/MaterialDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import THREEElementDescriptor from '../THREEElementDescriptor';
 import invariant from 'fbjs/lib/invariant';
 

--- a/src/descriptors/Material/MeshBasicMaterialDescriptor.js
+++ b/src/descriptors/Material/MeshBasicMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Material/MeshDepthMaterialDescriptor.js
+++ b/src/descriptors/Material/MeshDepthMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Material/MeshLambertMaterialDescriptor.js
+++ b/src/descriptors/Material/MeshLambertMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Material/MeshNormalMaterialDescriptor.js
+++ b/src/descriptors/Material/MeshNormalMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Material/MeshPhongMaterialDescriptor.js
+++ b/src/descriptors/Material/MeshPhongMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Material/PointsMaterialDescriptor.js
+++ b/src/descriptors/Material/PointsMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Material/ShaderMaterialDescriptor.js
+++ b/src/descriptors/Material/ShaderMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 
 import UniformContainer from '../../UniformContainer';

--- a/src/descriptors/Material/SpriteMaterialDescriptor.js
+++ b/src/descriptors/Material/SpriteMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Material/TextureDescriptor.js
+++ b/src/descriptors/Material/TextureDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import THREEElementDescriptor from '../THREEElementDescriptor';
 
 import invariant from 'fbjs/lib/invariant';

--- a/src/descriptors/Material/UniformDescriptor.js
+++ b/src/descriptors/Material/UniformDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import THREEElementDescriptor from '../THREEElementDescriptor';
 

--- a/src/descriptors/Material/UniformsDescriptor.js
+++ b/src/descriptors/Material/UniformsDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import THREEElementDescriptor from '../THREEElementDescriptor';
 

--- a/src/descriptors/Object/Camera/CameraDescriptorBase.js
+++ b/src/descriptors/Object/Camera/CameraDescriptorBase.js
@@ -1,5 +1,5 @@
 import Object3DDescriptor from '../Object3DDescriptor';
-import THREE from 'three.js';
+import THREE from 'three';
 
 class CameraDescriptorBase extends Object3DDescriptor {
   applyInitialProps(threeObject, props) {

--- a/src/descriptors/Object/Camera/CubeCameraDescriptor.js
+++ b/src/descriptors/Object/Camera/CubeCameraDescriptor.js
@@ -1,5 +1,5 @@
 import Object3DDescriptor from '../Object3DDescriptor';
-import THREE from 'three.js';
+import THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/descriptors/Object/Camera/OrthographicCameraDescriptor.js
+++ b/src/descriptors/Object/Camera/OrthographicCameraDescriptor.js
@@ -1,5 +1,5 @@
 import CameraDescriptorBase from './CameraDescriptorBase';
-import THREE from 'three.js';
+import THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/descriptors/Object/Camera/PerspectiveCameraDescriptor.js
+++ b/src/descriptors/Object/Camera/PerspectiveCameraDescriptor.js
@@ -1,5 +1,5 @@
 import CameraDescriptorBase from './CameraDescriptorBase';
-import THREE from 'three.js';
+import THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/descriptors/Object/GroupDescriptor.js
+++ b/src/descriptors/Object/GroupDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import Object3DDescriptor from './Object3DDescriptor';
 

--- a/src/descriptors/Object/Helper/ArrowHelperDescriptor.js
+++ b/src/descriptors/Object/Helper/ArrowHelperDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import Object3DDescriptor from '../Object3DDescriptor';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Object/Helper/AxisHelperDescriptor.js
+++ b/src/descriptors/Object/Helper/AxisHelperDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import Object3DDescriptor from '../Object3DDescriptor';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/Object/Helper/CameraHelperDescriptor.js
+++ b/src/descriptors/Object/Helper/CameraHelperDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import CameraUtils from '../../../utils/CameraUtils.js';
 import Object3DDescriptor from '../Object3DDescriptor';
 

--- a/src/descriptors/Object/LineDescriptor.js
+++ b/src/descriptors/Object/LineDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import Object3DDescriptor from './Object3DDescriptor';
 
 import ResourceReference from '../../Resources/ResourceReference';

--- a/src/descriptors/Object/MeshDescriptor.js
+++ b/src/descriptors/Object/MeshDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import Object3DDescriptor from './Object3DDescriptor';
 
 import ResourceReference from '../../Resources/ResourceReference';

--- a/src/descriptors/Object/Object3DDescriptor.js
+++ b/src/descriptors/Object/Object3DDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 import THREEElementDescriptor from '../THREEElementDescriptor';
 

--- a/src/descriptors/Object/PointsDescriptor.js
+++ b/src/descriptors/Object/PointsDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import MeshDescriptor from './MeshDescriptor';
 
 class PointsDescriptor extends MeshDescriptor {

--- a/src/descriptors/Object/SceneDescriptor.js
+++ b/src/descriptors/Object/SceneDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import Object3DDescriptor from './Object3DDescriptor';
 
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/descriptors/React3Descriptor.js
+++ b/src/descriptors/React3Descriptor.js
@@ -2,7 +2,7 @@ import React3DInstance from '../React3Instance';
 
 import THREEElementDescriptor from './THREEElementDescriptor';
 
-import THREE from 'three.js';
+import THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/descriptors/Resource/GeometryResourceDescriptor.js
+++ b/src/descriptors/Resource/GeometryResourceDescriptor.js
@@ -1,5 +1,5 @@
 import ResourceDescriptorBase from './ResourceDescriptorBase';
-import THREE from 'three.js';
+import THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 

--- a/src/descriptors/Resource/MaterialResourceDescriptor.js
+++ b/src/descriptors/Resource/MaterialResourceDescriptor.js
@@ -1,5 +1,5 @@
 import ResourceDescriptorBase from './ResourceDescriptorBase';
-import THREE from 'three.js';
+import THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 

--- a/src/descriptors/Resource/ResourcesDescriptor.js
+++ b/src/descriptors/Resource/ResourcesDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 import THREEElementDescriptor from '../THREEElementDescriptor';
 import invariant from 'fbjs/lib/invariant';
 

--- a/src/descriptors/Resource/ShapeGeometryResourceDescriptor.js
+++ b/src/descriptors/Resource/ShapeGeometryResourceDescriptor.js
@@ -1,6 +1,6 @@
 import GeometryResourceDescriptor from './GeometryResourceDescriptor';
 import PropTypes from 'react/lib/ReactPropTypes';
-import THREE from 'three.js';
+import THREE from 'three';
 
 class ShapeGeometryResourceDescriptor extends GeometryResourceDescriptor {
   constructor(react3RendererInstance) {

--- a/src/descriptors/Resource/ShapeResourceDescriptor.js
+++ b/src/descriptors/Resource/ShapeResourceDescriptor.js
@@ -1,5 +1,5 @@
 import ResourceDescriptorBase from './ResourceDescriptorBase';
-import THREE from 'three.js';
+import THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 

--- a/src/descriptors/Resource/TextureResourceDescriptor.js
+++ b/src/descriptors/Resource/TextureResourceDescriptor.js
@@ -1,5 +1,5 @@
 import ResourceDescriptorBase from './ResourceDescriptorBase';
-import THREE from 'three.js';
+import THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 

--- a/src/utils/CameraUtils.js
+++ b/src/utils/CameraUtils.js
@@ -1,4 +1,4 @@
-import THREE from 'three.js';
+import THREE from 'three';
 
 class CameraUtils {
   /**


### PR DESCRIPTION
In the beginning there was only one npm package for three.js, called
`three` as in `npm install three`. It's maintained by @bhouston.
Recently @mrdoob added a new npm module that he maintains, called
`three.js`, as in `npm install three.js`. This react-three-renderer
repository uses the newer `three.js`. However, the newer `three.js` npm
package is broken and contains invalid javascript, which will break any
build using a webpack/browserify/etc build compilation step with
something like:

    if ( self.requestAnimationFrame === undefined || self.cancelAnimationFrame === undefined  ) {
            ^
        ReferenceError: self is not defined

This ripples down into users of this react-three-renderer repository
because we are forced to use `three.js` to make our prop types the same.
For instance, new THREE.Vector3() passed as a prop from user land (using
`three`) will fail in this repo, because it's a different THREE object than
`three.js`.

The quick fix is to use the older, more mature, and functional `three`
npm package for now.

See https://github.com/mrdoob/three.js/issues/7800 for the full story.