### PR TITLE
Upgrading project to work with latest babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,7 @@ ReactDOM.render(<Simple/>, document.body);
 Building
 ========
 
-Fork and clone this repository, then do a npm install. 
-
-You also need to have webpack, gulp, and babel installed globally.
+Fork and clone this repository, then do a npm install.
 
 ``` gulp babel ``` produces es5 compatible code in the 'lib' directory.
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -9,8 +9,8 @@ gulp.task('clean-lib', () => {
 gulp.task('babel', ['clean-lib'], () => {
   return gulp.src('src/**/*.js')
     .pipe(babel({
-      optional: ['runtime'],
-      stage: 0,
+      plugins: ['transform-runtime', 'transform-decorators-legacy'],
+      presets: ['es2015', 'stage-0', 'react']
     }))
     .pipe(gulp.dest('lib/'));
 });

--- a/package.json
+++ b/package.json
@@ -18,30 +18,40 @@
     "three.js": "^0.73.0"
   },
   "devDependencies": {
-    "fbjs": ">=0.4.0",
-    "react": ">=0.14.1",
-    "react-dom": ">=0.14.1",
-    "three.js": ">=0.73.0",
-    "babel-core": "^5.8.29",
-    "babel-eslint": "^4.1.3",
-    "babel-runtime": "^5.8.29",
+    "babel-cli": "^6.3.17",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-runtime": "^6.3.13",
+    "babel-polyfill": "^6.3.14",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
     "del": "^2.0.2",
     "eslint": "^1.7.3",
     "eslint-config-airbnb": "^0.1.0",
     "eslint-plugin-react": "^3.6.3",
+    "fbjs": ">=0.4.0",
     "gulp": "^3.9.0",
-    "gulp-babel": "^5.3.0",
+    "gulp-babel": "^6.1.1",
     "gulp-util": "^3.0.7",
-    "in-publish": "^2.0.0"
+    "in-publish": "^2.0.0",
+    "react": ">=0.14.1",
+    "react-dom": ">=0.14.1",
+    "three": ">=0.73.0",
+    "webpack": "^1.12.9"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/toxicFork/react-three-renderer.git"
   },
   "babel": {
-    "stage": 0,
-    "optional": [
-      "runtime"
+    "presets": [
+      "es2015",
+      "stage-0",
+      "react"
+    ],
+    "plugins": [
+      "transform-runtime",
+      "transform-decorators-legacy"
     ]
   },
   "bugs": {


### PR DESCRIPTION
It's considered best practice to not rely on global babel, etc, to build
a project. (citation needed). This specifies all dev dependencies
needed. This increases the npm install time but ultimately makes the
project more reliable.

Decorators are not fully supported in babel 6x so a plugin is required
to make them work.

It took a long time to track down all the bugs so please don't make me
do this again :)