### PR TITLE
[core] Enable replacement of composite components

### DIFF
--- a/src/lib/React3CompositeComponentWrapper.js
+++ b/src/lib/React3CompositeComponentWrapper.js
@@ -52,6 +52,30 @@ class React3CompositeComponentWrapper extends ReactCompositeComponentMixinImpl {
     return this._react3RendererInstance.instantiateReactComponent(element);
   }
 
+  _replaceNodeWithMarkupByID(prevComponentID, nextMarkup) {
+    const markup = this._react3RendererInstance.getMarkup(prevComponentID);
+
+    const parentMarkup = markup.parentMarkup;
+
+    const ownerChildrenMarkups = parentMarkup.childrenMarkup;
+
+    const indexInParent = ownerChildrenMarkups.indexOf(markup);
+
+    if (process.env.NODE_ENV !== 'production') {
+      invariant(indexInParent !== -1, 'The node has no parent');
+    } else {
+      invariant(indexInParent !== -1);
+    }
+
+    const parentInternalComponent = parentMarkup.threeObject.userData.react3internalComponent;
+    const originalInternalComponent = markup.threeObject.userData.react3internalComponent;
+
+    parentInternalComponent.removeChild(originalInternalComponent);
+    const nextChild = nextMarkup.threeObject.userData.react3internalComponent;
+    nextChild._mountIndex = indexInParent;
+    parentInternalComponent.createChild(nextChild, nextMarkup);
+  }
+
   // See ReactCompositeComponent.mountComponent
   mountComponent(rootID, transaction, context) {
     this._context = context;

--- a/tests/src/core/React3/React3Mounts.js
+++ b/tests/src/core/React3/React3Mounts.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import chai from 'chai';
+import THREE from 'three';
 
 module.exports = type => {
   const { testDiv, React3, mockConsole } = require('../../utils/initContainer')(type);
@@ -236,5 +237,201 @@ module.exports = type => {
         res
       />
     </React3>, testDiv);
+  });
+
+  it('can replace component rendered by a composite', () => {
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <scene/>
+    </React3>, testDiv);
+
+    mockConsole.expect('THREE.WebGLRenderer	74');
+    /* eslint-disable react/no-multi-comp */
+
+    let cameraReference = null;
+
+    const cameraRef = (_cameraReference) => {
+      cameraReference = _cameraReference;
+    };
+
+    let meshReference = null;
+
+    const meshRef = (_meshReference) => {
+      meshReference = _meshReference;
+    };
+
+    let boxReference = null;
+
+    const boxRef = (_boxReference) => {
+      boxReference = _boxReference;
+    };
+
+    let matReference = null;
+
+    const matRef = (_matReference) => {
+      matReference = _matReference;
+    };
+
+    let groupReference = null;
+
+    const groupRef = (_groupReference) => {
+      groupReference = _groupReference;
+    };
+
+    let objReference = null;
+
+    const objRef = (_objReference) => {
+      objReference = _objReference;
+    };
+
+    let subTestReference = null;
+
+    const subTestRef = (_subTestReference) => {
+      subTestReference = _subTestReference;
+    };
+
+
+    class TestComponent extends React.Component {
+      static propTypes = {
+        type: React.PropTypes.string.isRequired,
+      };
+
+      render() {
+        switch (this.props.type) {
+          case 'camera':
+            return (<perspectiveCamera ref={cameraRef}/>);
+          case 'mesh':
+            return (<mesh ref={meshRef}>
+              <boxGeometry
+                ref={boxRef}
+                width={5}
+                height={5}
+                depth={5}
+              />
+              <meshBasicMaterial
+                ref={matRef}
+              />
+            </mesh>);
+          case 'group':
+            return (<group
+              ref={groupRef}
+            />);
+          case 'deeper':
+            return (<TestComponent
+              type="group"
+              ref={subTestRef}
+            />);
+          default:
+            return (<object3D
+              ref={objRef}
+            />);
+        }
+      }
+    }
+
+    /* eslint-enable */
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <scene>
+        <TestComponent type="camera"/>
+      </scene>
+    </React3>, testDiv);
+
+    expect(cameraReference).not.to.be.null();
+    expect(cameraReference).to.be.instanceOf(THREE.PerspectiveCamera);
+    expect(meshReference).to.be.null();
+    expect(boxReference).to.be.null();
+    expect(matReference).to.be.null();
+    expect(groupReference).to.be.null();
+    expect(objReference).to.be.null();
+    expect(subTestReference).to.be.null();
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <scene>
+        <TestComponent type="mesh"/>
+      </scene>
+    </React3>, testDiv);
+
+    expect(cameraReference).to.be.null();
+
+    expect(meshReference).not.to.be.null();
+    expect(boxReference).not.to.be.null();
+    expect(matReference).not.to.be.null();
+
+    expect(meshReference).to.be.instanceOf(THREE.Mesh);
+    expect(boxReference).to.be.instanceOf(THREE.BoxGeometry);
+    expect(matReference).to.be.instanceOf(THREE.MeshBasicMaterial);
+
+    expect(groupReference).to.be.null();
+    expect(objReference).to.be.null();
+    expect(subTestReference).to.be.null();
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <scene>
+        <TestComponent type="group"/>
+      </scene>
+    </React3>, testDiv);
+
+    expect(cameraReference).to.be.null();
+    expect(meshReference).to.be.null();
+    expect(boxReference).to.be.null();
+    expect(matReference).to.be.null();
+    expect(groupReference).not.to.be.null();
+
+    expect(groupReference).to.be.instanceOf(THREE.Group);
+
+    expect(objReference).to.be.null();
+    expect(subTestReference).to.be.null();
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <scene>
+        <TestComponent type="asdf"/>
+      </scene>
+    </React3>, testDiv);
+
+    expect(cameraReference).to.be.null();
+    expect(meshReference).to.be.null();
+    expect(boxReference).to.be.null();
+    expect(matReference).to.be.null();
+    expect(groupReference).to.be.null();
+    expect(objReference).not.to.be.null();
+
+    expect(objReference).to.be.instanceOf(THREE.Object3D);
+    expect(subTestReference).to.be.null();
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <scene>
+        <TestComponent type="deeper"/>
+      </scene>
+    </React3>, testDiv);
+
+    expect(cameraReference).to.be.null();
+    expect(meshReference).to.be.null();
+    expect(boxReference).to.be.null();
+    expect(matReference).to.be.null();
+    expect(objReference).to.be.null();
+
+    expect(subTestReference).not.to.be.null();
+    expect(groupReference).not.to.be.null();
+
+    expect(subTestReference).to.be.instanceOf(TestComponent);
+    expect(groupReference).to.be.instanceOf(THREE.Group);
   });
 };

--- a/tests/src/core/React3/React3Mounts.js
+++ b/tests/src/core/React3/React3Mounts.js
@@ -39,4 +39,202 @@ module.exports = type => {
 
     expect(canvas.userData).to.exist();
   });
+
+  it('can replace internal components with composites and vice versa', () => {
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <scene/>
+    </React3>, testDiv);
+
+    mockConsole.expect('THREE.WebGLRenderer	74');
+
+    let mounted = false;
+
+    /* eslint-disable react/no-multi-comp */
+
+    class MyScene extends React.Component {
+      componentDidMount() {
+        mounted = true;
+      }
+
+      componentWillUnmount() {
+        mounted = false;
+      }
+
+      render() {
+        return (<scene/>);
+      }
+    }
+
+    class MyResources extends React.Component {
+      render() {
+        return (<resources/>);
+      }
+    }
+
+    class Wrapper extends React.Component {
+      static propTypes = {
+        internal: React.PropTypes.bool,
+        res: React.PropTypes.bool,
+      };
+
+      render() {
+        if (this.props.internal) {
+          return (<scene/>);
+        }
+
+        if (this.props.res) {
+          return (<MyResources/>);
+        }
+
+        return (<MyScene/>);
+      }
+    }
+
+    /* eslint-enable */
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <Wrapper
+        internal
+      />
+    </React3>, testDiv);
+
+    expect(mounted).to.equal(false);
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <Wrapper internal={false}/>
+    </React3>, testDiv);
+
+    expect(mounted).to.equal(true);
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <Wrapper
+        internal
+      />
+    </React3>, testDiv);
+
+    expect(mounted).to.equal(false);
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <Wrapper
+        res
+      />
+    </React3>, testDiv);
+  });
+
+  it('can replace internal components with composites and vice versa ' +
+    'with a previous sibling', () => {
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <viewport x={0} y={0} width={0} height={0} cameraName="test"/>
+      <scene/>
+    </React3>, testDiv);
+
+    mockConsole.expect('THREE.WebGLRenderer	74');
+
+    let mounted = false;
+
+    /* eslint-disable react/no-multi-comp */
+
+    class MyScene extends React.Component {
+      componentDidMount() {
+        mounted = true;
+      }
+
+      componentWillUnmount() {
+        mounted = false;
+      }
+
+      render() {
+        return (<scene/>);
+      }
+    }
+
+    class MyResources extends React.Component {
+      render() {
+        return (<resources/>);
+      }
+    }
+
+    class Wrapper extends React.Component {
+      static propTypes = {
+        internal: React.PropTypes.bool,
+        res: React.PropTypes.bool,
+      };
+
+      render() {
+        if (this.props.internal) {
+          return (<scene/>);
+        }
+
+        if (this.props.res) {
+          return (<MyResources/>);
+        }
+
+        return (<MyScene/>);
+      }
+    }
+
+    /* eslint-enable */
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <viewport x={0} y={0} width={0} height={0} cameraName="test"/>
+      <Wrapper
+        internal
+      />
+    </React3>, testDiv);
+
+    expect(mounted).to.equal(false);
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <viewport x={0} y={0} width={0} height={0} cameraName="test"/>
+      <Wrapper internal={false}/>
+    </React3>, testDiv);
+
+    expect(mounted).to.equal(true);
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <viewport x={0} y={0} width={0} height={0} cameraName="test"/>
+      <Wrapper
+        internal
+      />
+    </React3>, testDiv);
+
+    expect(mounted).to.equal(false);
+
+    ReactDOM.render(<React3
+      width={800}
+      height={600}
+    >
+      <viewport x={0} y={0} width={0} height={0} cameraName="test"/>
+      <Wrapper
+        res
+      />
+    </React3>, testDiv);
+  });
 };

--- a/tests/src/start-testing.js
+++ b/tests/src/start-testing.js
@@ -13,10 +13,10 @@ chai.use(dirtyChai);
 module.exports = (type) => {
   describe(`${type}/React3`, () => {
     require('./core/React3/React3Mounts')(type);
+  });
 
-    describe(`ManualRendering`, () => {
-      require('./core/Warnings/ManualRendering')(type);
-    });
+  describe(`${type}/React3/ManualRendering`, () => {
+    require('./core/Warnings/ManualRendering')(type);
   });
 
   describe(`${type}/Warnings`, () => {

--- a/tests/src/utils/MockConsole.js
+++ b/tests/src/utils/MockConsole.js
@@ -38,6 +38,27 @@ module.exports = class MockConsole {
     this._events.removeAllListeners();
 
     if (ignoreChecks) {
+      this._messages.forEach(message => {
+        let func = null;
+
+        switch (message.args.type) {
+          case 'LOG':
+            func = window.console.log;
+            break;
+          case 'WARNING':
+            func = window.console.warning;
+            break;
+          case 'ERROR':
+          default:
+            func = window.console.error;
+            break;
+        }
+
+        delete message.args.type;
+
+        func.apply(window.console, message.args);
+      });
+
       this._messages = [];
       this._expectedMessages = [];
 


### PR DESCRIPTION
This fixes a bug where composite components could not change the type of the returned component.

For example:

```jsx
    class Wrapper extends React.Component {
      static propTypes = {
        internal: React.PropTypes.bool,
        res: React.PropTypes.bool,
      };

      render() {
        if (this.props.internal) {
          return (<scene/>);
        }

        if (this.props.res) {
          return (<MyResources/>);
        }

        return (<MyScene/>);
      }
    }
```

This would result in a crash.

Now it won't crash :)