### PR TITLE
Allow using an alternate renderer via `createRenderer` prop

### DIFF
--- a/src/lib/React3.js
+++ b/src/lib/React3.js
@@ -19,6 +19,7 @@ class React3 extends React.Component {
     gammaOutput: PropTypes.bool,
     sortObjects: PropTypes.bool,
     mainCamera: PropTypes.string,
+    createRenderer: PropTypes.func,
     onAnimate: PropTypes.func,
     clearColor: PropTypes.oneOfType([
       propTypeInstanceOf(THREE.Color),

--- a/src/lib/React3Instance.js
+++ b/src/lib/React3Instance.js
@@ -683,7 +683,13 @@ class React3DInstance {
       }
     }
 
-    this._createRenderer();
+    if (this._parameters.createRenderer) {
+      this._renderer = this._parameters.createRenderer();
+    }
+
+    if (!this._renderer) {
+      this._createRenderer();
+    }
   }
 
   updateGammaInput(gammaInput) {
@@ -716,6 +722,12 @@ class React3DInstance {
     this._parameters.mainCamera = mainCamera;
 
     this._mainCameraName = mainCamera;
+  }
+
+  updateCreateRenderer(createRenderer) {
+    this._parameters.createRenderer = createRenderer;
+
+    this.createRenderer = createRenderer;
   }
 
   updateOnAnimate(onAnimate) {

--- a/src/lib/descriptors/React3Descriptor.js
+++ b/src/lib/descriptors/React3Descriptor.js
@@ -34,6 +34,10 @@ const propProxy = {
     type: PropTypes.string,
     default: undefined,
   },
+  createRenderer: {
+    type: PropTypes.func,
+    default: undefined,
+  },
   onAnimate: {
     type: PropTypes.func,
     default: undefined,


### PR DESCRIPTION
Allow using alternate ThreeJS renderers (such as Altspace's renderer) or alternate configurations of `WebGLRenderer`. The `createRenderer` function is passed react3instanc's properties which it can use in creating the renderer. This would also be able to handle the case covered by #53 though it may still make sense to bake in that fallback.
