### PR TITLE
Move common Geometry props to GeometryDescriptorBase

### DIFF
--- a/src/lib/descriptors/Geometry/GeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/GeometryDescriptor.js
@@ -9,56 +9,13 @@ class GeometryDescriptor extends GeometryDescriptorBase {
     super(react3RendererInstance);
 
     this.hasProp('vertices', {
+      override: true,
       type: PropTypes.arrayOf(propTypeInstanceOf(THREE.Vector3)).isRequired,
       update(threeObject, vertices) {
         if (threeObject.vertices !== vertices) {
           threeObject.vertices = vertices;
 
           threeObject.verticesNeedUpdate = true;
-        }
-      },
-      updateInitial: true,
-      default: [],
-    });
-
-    this.hasProp('colors', {
-      type: PropTypes.arrayOf(propTypeInstanceOf(THREE.Color)),
-      update(threeObject, colors, hasProp) {
-        if (hasProp) {
-          if (threeObject.colors !== colors) {
-            threeObject.colors = colors;
-
-            threeObject.colorsNeedUpdate = true;
-          }
-        }
-      },
-      updateInitial: true,
-      default: [],
-    });
-
-    this.hasProp('faceVertexUvs', {
-      type: PropTypes.arrayOf(PropTypes.arrayOf(THREE.Vector2)),
-      update(threeObject, faceVertexUvs, hasProp) {
-        if (hasProp) {
-          if (threeObject.faceVertexUvs !== faceVertexUvs) {
-            threeObject.faceVertexUvs = faceVertexUvs;
-
-            threeObject.uvsNeedUpdate = true;
-          }
-        }
-      },
-      updateInitial: true,
-      default: [],
-    });
-
-    this.hasProp('faces', {
-      type: PropTypes.arrayOf(propTypeInstanceOf(THREE.Face3)),
-      update(threeObject, faces) {
-        if (threeObject.faces !== faces) {
-          threeObject.faces = faces;
-
-          threeObject.verticesNeedUpdate = true;
-          threeObject.elementsNeedUpdate = true;
         }
       },
       updateInitial: true,

--- a/src/lib/descriptors/Geometry/GeometryDescriptorBase.js
+++ b/src/lib/descriptors/Geometry/GeometryDescriptorBase.js
@@ -6,11 +6,74 @@ import invariant from 'fbjs/lib/invariant';
 import resource from '../decorators/resource';
 
 import PropTypes from 'react/lib/ReactPropTypes';
+import propTypeInstanceOf from '../../utils/propTypeInstanceOf';
 
 @resource
 class GeometryDescriptorBase extends THREEElementDescriptor {
   constructor(react3RendererInstance) {
     super(react3RendererInstance);
+
+    this.hasProp('vertices', {
+      type: PropTypes.arrayOf(propTypeInstanceOf(THREE.Vector3)),
+      update(threeObject, vertices, hasProp) {
+        if (hasProp) {
+          if (threeObject.vertices !== vertices) {
+            threeObject.vertices = vertices;
+
+            threeObject.verticesNeedUpdate = true;
+          }
+        }
+      },
+      updateInitial: true,
+      default: [],
+    });
+
+    this.hasProp('colors', {
+      type: PropTypes.arrayOf(propTypeInstanceOf(THREE.Color)),
+      update(threeObject, colors, hasProp) {
+        if (hasProp) {
+          if (threeObject.colors !== colors) {
+            threeObject.colors = colors;
+
+            threeObject.colorsNeedUpdate = true;
+          }
+        }
+      },
+      updateInitial: true,
+      default: [],
+    });
+
+    this.hasProp('faceVertexUvs', {
+      type: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(THREE.Vector2))),
+      update(threeObject, faceVertexUvs, hasProp) {
+        if (hasProp) {
+          if (threeObject.faceVertexUvs !== faceVertexUvs) {
+            threeObject.faceVertexUvs = faceVertexUvs;
+
+            threeObject.uvsNeedUpdate = true;
+          }
+        }
+      },
+      updateInitial: true,
+      default: [],
+    });
+
+    this.hasProp('faces', {
+      type: PropTypes.arrayOf(propTypeInstanceOf(THREE.Face3)),
+      update(threeObject, faces, hasProp) {
+        if (hasProp) {
+          if (threeObject.faces !== faces) {
+            threeObject.faces = faces;
+
+            threeObject.verticesNeedUpdate = true;
+            threeObject.elementsNeedUpdate = true;
+          }
+        }
+      },
+      updateInitial: true,
+      default: [],
+    });
+
 
     this.hasProp('dynamic', {
       type: PropTypes.bool,

--- a/src/lib/descriptors/Geometry/PolyhedronGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/PolyhedronGeometryDescriptor.js
@@ -7,15 +7,18 @@ class PolyhedronGeometryDescriptor extends PolyhedronGeometryDescriptorBase {
   constructor(react3RendererInstance) {
     super(react3RendererInstance);
 
-    [
-      'vertices',
-      'indices',
-    ].forEach(propName => {
-      this.hasProp(propName, {
-        type: PropTypes.arrayOf(PropTypes.number).isRequired,
-        update: this.triggerRemount,
-        default: undefined,
-      });
+
+    this.hasProp('vertices', {
+      override: true,
+      type: PropTypes.arrayOf(PropTypes.number).isRequired,
+      update: this.triggerRemount,
+      default: undefined,
+    });
+
+    this.hasProp('indices', {
+      type: PropTypes.arrayOf(PropTypes.number).isRequired,
+      update: this.triggerRemount,
+      default: undefined,
     });
   }
 

--- a/wiki/boxGeometry.md
+++ b/wiki/boxGeometry.md
@@ -14,6 +14,18 @@ Creates a [THREE.BoxGeometry](http://threejs.org/docs/#Reference/Extras.Geometri
 ### depth
 ``` number ``` *``` required ```*: Depth of the sides on the Z axis.
 
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/circleBufferGeometry.md
+++ b/wiki/circleBufferGeometry.md
@@ -5,6 +5,18 @@
 Creates a [THREE.CircleBufferGeometry](http://threejs.org/docs/#Reference/Extras.Geometries/CircleBufferGeometry)
 
 ## Attributes
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/circleGeometry.md
+++ b/wiki/circleGeometry.md
@@ -13,6 +13,18 @@ It is constructed from a number of triangular segments that are oriented
  segments determines the number of sides.
 
 ## Attributes
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/cylinderGeometry.md
+++ b/wiki/cylinderGeometry.md
@@ -5,6 +5,18 @@
 Creates a [THREE.CylinderGeometry](http://threejs.org/docs/#Reference/Extras.Geometries/CylinderGeometry)
 
 ## Attributes
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/dodecahedronGeometry.md
+++ b/wiki/dodecahedronGeometry.md
@@ -5,6 +5,18 @@
 Creates a [THREE.DodecahedronGeometry](http://threejs.org/docs/index.html#Reference/Extras.Geometries/DodecahedronGeometry)
 
 ## Attributes
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/extrudeGeometry.md
+++ b/wiki/extrudeGeometry.md
@@ -14,6 +14,18 @@ This is to prevent having to remount the component every time anything changes.
  
 
 ## Attributes
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/geometry.md
+++ b/wiki/geometry.md
@@ -8,6 +8,15 @@ Creates a [THREE.Geometry](http://threejs.org/docs/#Reference/Extras.Geometries/
 ### vertices
 ``` array of THREE.Vector3 ``` *``` required ```*: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
 
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 
@@ -21,15 +30,6 @@ Defaults to true.
 ``` string ```: Name for this geometry.
 
 Default is an empty string.
-
-### colors
-``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
-
-### faceVertexUvs
-``` array of (array of THREE.Vector2) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
-
-### faces
-``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
 
 ### resourceId
 ``` string ```: The resource id of this object, only used if it is placed into [[resources]].

--- a/wiki/icosahedronGeometry.md
+++ b/wiki/icosahedronGeometry.md
@@ -11,6 +11,18 @@ Creates a [THREE.IcosahedronGeometry](http://threejs.org/docs/#Reference/Extras.
 ### detail
 ``` number ``` *``` required ```*
 
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/latheGeometry.md
+++ b/wiki/latheGeometry.md
@@ -8,6 +8,18 @@ Creates a [THREE.LatheGeometry](http://threejs.org/docs/#Reference/Extras.Geomet
 ### points
 ``` array of THREE.Vector2 ``` *``` required ```*
 
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/octahedronGeometry.md
+++ b/wiki/octahedronGeometry.md
@@ -11,6 +11,18 @@ Creates a [THREE.OctahedronGeometry](http://threejs.org/docs/#Reference/Extras.G
 ### detail
 ``` number ``` *``` required ```*
 
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/parametricGeometry.md
+++ b/wiki/parametricGeometry.md
@@ -14,6 +14,18 @@ Creates a [THREE.ParametricGeometry](http://threejs.org/docs/#Reference/Extras.G
 ### parametricFunction
 ``` function ``` *``` required ```*
 
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/planeBufferGeometry.md
+++ b/wiki/planeBufferGeometry.md
@@ -11,6 +11,18 @@ Creates a [THREE.PlaneBufferGeometry](http://threejs.org/docs/#Reference/Extras.
 ### height
 ``` number ``` *``` required ```*
 
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/planeGeometry.md
+++ b/wiki/planeGeometry.md
@@ -11,6 +11,18 @@ Creates a [THREE.PlaneGeometry](http://threejs.org/docs/#Reference/Extras.Geomet
 ### height
 ``` number ``` *``` required ```*
 
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/polyhedronGeometry.md
+++ b/wiki/polyhedronGeometry.md
@@ -5,17 +5,26 @@
 Creates a [THREE.PolyhedronGeometry](http://threejs.org/docs/#Reference/Extras.Geometries/PolyhedronGeometry)
 
 ## Attributes
+### vertices
+``` array of number ``` *``` required ```*
+
 ### radius
 ``` number ``` *``` required ```*
 
 ### detail
 ``` number ``` *``` required ```*
 
-### vertices
-``` array of number ``` *``` required ```*
-
 ### indices
 ``` array of number ``` *``` required ```*
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
 
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).

--- a/wiki/ringGeometry.md
+++ b/wiki/ringGeometry.md
@@ -5,6 +5,18 @@
 Creates a [THREE.RingGeometry](http://threejs.org/docs/#Reference/Extras.Geometries/RingGeometry)
 
 ## Attributes
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/sphereGeometry.md
+++ b/wiki/sphereGeometry.md
@@ -5,6 +5,18 @@
 Creates a [THREE.SphereGeometry](http://threejs.org/docs/#Reference/Extras.Geometries/SphereGeometry)
 
 ## Attributes
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/tetrahedronGeometry.md
+++ b/wiki/tetrahedronGeometry.md
@@ -11,6 +11,18 @@ Creates a [THREE.TetrahedronGeometry](http://threejs.org/docs/#Reference/Extras.
 ### detail
 ``` number ``` *``` required ```*
 
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/textGeometry.md
+++ b/wiki/textGeometry.md
@@ -14,6 +14,18 @@ Creates a [THREE.TextGeometry](http://threejs.org/docs/#Reference/Extras.Geometr
 ### size
 ``` number ``` *``` required ```*: The size of the text.
 
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/torusGeometry.md
+++ b/wiki/torusGeometry.md
@@ -5,6 +5,18 @@
 Creates a [THREE.TorusGeometry](http://threejs.org/docs/#Reference/Extras.Geometries/TorusGeometry)
 
 ## Attributes
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/torusKnotGeometry.md
+++ b/wiki/torusKnotGeometry.md
@@ -5,6 +5,18 @@
 Creates a [THREE.TorusKnotGeometry](http://threejs.org/docs/#Reference/Extras.Geometries/TorusKnotGeometry)
 
 ## Attributes
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 

--- a/wiki/tubeGeometry.md
+++ b/wiki/tubeGeometry.md
@@ -5,6 +5,18 @@
 Creates a [THREE.TubeGeometry](http://threejs.org/docs/#Reference/Extras.Geometries/TubeGeometry)
 
 ## Attributes
+### vertices
+``` array of THREE.Vector3 ```: See [THREE.Geometry#vertices](http://threejs.org/docs/#Reference/Core/Geometry.vertices).
+
+### colors
+``` array of THREE.Color ```: See [THREE.Geometry#colors](http://threejs.org/docs/#Reference/Core/Geometry.colors).
+
+### faceVertexUvs
+``` array of (array of (array of THREE.Vector2)) ```: See [THREE.Geometry#faceVertexUvs](http://threejs.org/docs/#Reference/Core/Geometry.faceVertexUvs).
+
+### faces
+``` array of THREE.Face3 ```: See [THREE.Geometry#faces](http://threejs.org/docs/#Reference/Core/Geometry.faces).
+
 ### dynamic
 ``` bool ```: See [THREE.Geometry#dynamic](http://threejs.org/docs/#Reference/Core/Geometry.dynamic).
 


### PR DESCRIPTION
One notable change is prop type of `faceVertexUvs `, which should be [][][]THREE.vector2, it was only [][]THREE.vector2 previously.

