### PR TITLE
AmbientLight: add 'intensity' prop

### DIFF
--- a/src/lib/descriptors/Light/AmbientLightDescriptor.js
+++ b/src/lib/descriptors/Light/AmbientLightDescriptor.js
@@ -1,10 +1,18 @@
 import THREE from 'three';
 
+import PropTypes from 'react/lib/ReactPropTypes';
+
 import LightDescriptorBase from './LightDescriptorBase';
 
 class AmbientLightDescriptor extends LightDescriptorBase {
   constructor(react3Instance) {
     super(react3Instance);
+
+    this.hasProp('intensity', {
+      type: PropTypes.number,
+      simple: true,
+      default: 1,
+    });
 
     this.hasColor();
   }
@@ -12,9 +20,10 @@ class AmbientLightDescriptor extends LightDescriptorBase {
   construct(props) {
     const {
       color,
-      } = props;
+      intensity,
+    } = props;
 
-    return new THREE.AmbientLight(color);
+    return new THREE.AmbientLight(color, intensity);
   }
 }
 


### PR DESCRIPTION
This is my first real PR, so feel free to tell me if there's something wrong.

This PR add the missing **intensity** prop in ambientLight.