### PR TITLE
Updating for compatibility with three@>=0.80.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Here's a simple example that implements the [getting started scene for three.js]
 ```js
 import React from 'react';
 import React3 from 'react-three-renderer';
-import THREE from 'three';
+import * as THREE from 'three';
 import ReactDOM from 'react-dom';
 
 class Simple extends React.Component {

--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "fbjs": "0.8.4"
+    "fbjs": "0.8.4",
+    "three": "^0.82.1"
   },
   "peerDependencies": {
     "react": "~15.3.0",
-    "three": ">=0.78.0 < 0.80.0"
+    "three": ">=0.80.0"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",
@@ -80,7 +81,7 @@
     "sinon": "2.0.0-pre",
     "source-map-support": "0.4.5",
     "stream-to-string": "1.1.0",
-    "three": "0.79.0",
+    "three": "0.82.1",
     "webpack": "1.13.3",
     "webpack-dev-server": "1.16.2"
   },

--- a/src/lib/ElementDescriptorContainer.js
+++ b/src/lib/ElementDescriptorContainer.js
@@ -69,6 +69,7 @@ import PointsMaterialDescriptor from './descriptors/Material/PointsMaterialDescr
 import MeshBasicMaterialDescriptor from './descriptors/Material/MeshBasicMaterialDescriptor';
 import MeshPhongMaterialDescriptor from './descriptors/Material/MeshPhongMaterialDescriptor';
 import MeshLambertMaterialDescriptor from './descriptors/Material/MeshLambertMaterialDescriptor';
+import MeshStandardMaterialDescriptor from './descriptors/Material/MeshStandardMaterialDescriptor';
 import ShaderMaterialDescriptor from './descriptors/Material/ShaderMaterialDescriptor';
 import RawShaderMaterialDescriptor from './descriptors/Material/RawShaderMaterialDescriptor';
 import TextureDescriptor from './descriptors/Material/TextureDescriptor';
@@ -117,6 +118,7 @@ class ElementDescriptorContainer {
       meshBasicMaterial: new MeshBasicMaterialDescriptor(react3RendererInstance),
       meshPhongMaterial: new MeshPhongMaterialDescriptor(react3RendererInstance),
       meshLambertMaterial: new MeshLambertMaterialDescriptor(react3RendererInstance),
+      meshStandardMaterial: new MeshStandardMaterialDescriptor(react3RendererInstance),
       pointsMaterial: new PointsMaterialDescriptor(react3RendererInstance),
       shaderMaterial: new ShaderMaterialDescriptor(react3RendererInstance),
       rawShaderMaterial: new RawShaderMaterialDescriptor(react3RendererInstance),

--- a/src/lib/ElementDescriptorContainer.js
+++ b/src/lib/ElementDescriptorContainer.js
@@ -22,6 +22,7 @@ import AmbientLightDescriptor from './descriptors/Light/AmbientLightDescriptor';
 import DirectionalLightDescriptor from './descriptors/Light/DirectionalLightDescriptor';
 import SpotLightDescriptor from './descriptors/Light/SpotLightDescriptor';
 import PointLightDescriptor from './descriptors/Light/PointLightDescriptor';
+import HemisphereLightDescriptor from './descriptors/Light/HemisphereLightDescriptor';
 
 import ResourcesDescriptor from './descriptors/Resource/ResourcesDescriptor';
 import GeometryResourceDescriptor from './descriptors/Resource/GeometryResourceDescriptor';
@@ -165,6 +166,7 @@ class ElementDescriptorContainer {
       directionalLight: new DirectionalLightDescriptor(react3RendererInstance),
       spotLight: new SpotLightDescriptor(react3RendererInstance),
       pointLight: new PointLightDescriptor(react3RendererInstance),
+      hemisphereLight: new HemisphereLightDescriptor(react3RendererInstance),
 
       resources: new ResourcesDescriptor(react3RendererInstance),
       materialResource: new MaterialResourceDescriptor(react3RendererInstance),

--- a/src/lib/Module.js
+++ b/src/lib/Module.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 class React3Module {
   constructor() {

--- a/src/lib/React3.jsx
+++ b/src/lib/React3.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PureRenderMixin from 'react/lib/ReactComponentWithPureRenderMixin';
-import THREE from 'three';
+import * as THREE from 'three';
 
 import React3Renderer from './React3Renderer';
 import propTypeInstanceOf from './utils/propTypeInstanceOf';

--- a/src/lib/React3Instance.js
+++ b/src/lib/React3Instance.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 import ReactUpdates from 'react/lib/ReactUpdates';

--- a/src/lib/React3Renderer.js
+++ b/src/lib/React3Renderer.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import reactElementWrapper from 'react/lib/ReactElement';
 import ReactInstanceMap from 'react/lib/ReactInstanceMap';
 import ReactInstanceHandles from 'react/lib/ReactInstanceHandles';

--- a/src/lib/Resources/ResourceContainer.js
+++ b/src/lib/Resources/ResourceContainer.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 class ResourceContainer extends THREE.Object3D {
   constructor() {

--- a/src/lib/Resources/ResourceReference.js
+++ b/src/lib/Resources/ResourceReference.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 class ResourceReference {
   constructor(resourceId) {

--- a/src/lib/Shapes/AbsArcAction.js
+++ b/src/lib/Shapes/AbsArcAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/lib/Shapes/AbsEllipseAction.js
+++ b/src/lib/Shapes/AbsEllipseAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/lib/Shapes/BezierCurveToAction.js
+++ b/src/lib/Shapes/BezierCurveToAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/lib/Shapes/HoleAction.js
+++ b/src/lib/Shapes/HoleAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/lib/Shapes/LineToAction.js
+++ b/src/lib/Shapes/LineToAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/lib/Shapes/MoveToAction.js
+++ b/src/lib/Shapes/MoveToAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/lib/Shapes/QuadraticCurveToAction.js
+++ b/src/lib/Shapes/QuadraticCurveToAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/lib/Shapes/ShapeAction.js
+++ b/src/lib/Shapes/ShapeAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 /**
  * @abstract

--- a/src/lib/Shapes/SplineThruAction.js
+++ b/src/lib/Shapes/SplineThruAction.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import ShapeAction from './ShapeAction';
 

--- a/src/lib/Uniform.js
+++ b/src/lib/Uniform.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 class Uniform {
   constructor() {

--- a/src/lib/UniformContainer.js
+++ b/src/lib/UniformContainer.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 class UniformContainer {
   constructor() {

--- a/src/lib/Viewport.js
+++ b/src/lib/Viewport.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 class Viewport {
   constructor(props) {

--- a/src/lib/descriptors/Geometry/BoxGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/BoxGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/BufferGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/BufferGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import PropTypes from 'react/lib/ReactPropTypes';
 
 import GeometryDescriptorBase from './GeometryDescriptorBase';

--- a/src/lib/descriptors/Geometry/CircleBufferGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/CircleBufferGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/CircleGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/CircleGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/CylinderGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/CylinderGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/DodecahedronGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/DodecahedronGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/EdgesGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/EdgesGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/ExtrudeGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/ExtrudeGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 
@@ -50,7 +50,8 @@ class ExtrudeGeometryDescriptor extends GeometryWithShapesDescriptor {
     const extraTypes = [
       PropTypes.bool, // bevelEnabled
       propTypeInstanceOf(THREE.CurvePath), // extrudePath
-      propTypeInstanceOf(THREE.TubeGeometry.FrenetFrames), // frames
+      // propTypeInstanceOf(THREE.TubeGeometry.FrenetFrames), // frames
+      PropTypes.object, // frames
     ];
 
     extraNames.forEach((propName, i) => {

--- a/src/lib/descriptors/Geometry/GeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/GeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import PropTypes from 'react/lib/ReactPropTypes';
 
 import GeometryDescriptorBase from './GeometryDescriptorBase';

--- a/src/lib/descriptors/Geometry/GeometryDescriptorBase.js
+++ b/src/lib/descriptors/Geometry/GeometryDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/lib/descriptors/Geometry/GeometryWithShapesDescriptor.js
+++ b/src/lib/descriptors/Geometry/GeometryWithShapesDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 import invariant from 'fbjs/lib/invariant';

--- a/src/lib/descriptors/Geometry/IcosahedronGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/IcosahedronGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import PolyhedronGeometryDescriptorBase from './PolyhedronGeometryDescriptorBase';
 
 class IcosahedronGeometryDescriptor extends PolyhedronGeometryDescriptorBase {

--- a/src/lib/descriptors/Geometry/LatheGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/LatheGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import PropTypes from 'react/lib/ReactPropTypes';
 
 import GeometryDescriptorBase from './GeometryDescriptorBase';

--- a/src/lib/descriptors/Geometry/OctahedronGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/OctahedronGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import PolyhedronGeometryDescriptorBase from './PolyhedronGeometryDescriptorBase';
 
 class OctahedronGeometryDescriptor extends PolyhedronGeometryDescriptorBase {

--- a/src/lib/descriptors/Geometry/ParametricGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/ParametricGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import PropTypes from 'react/lib/ReactPropTypes';
 
 import GeometryDescriptorBase from './GeometryDescriptorBase';

--- a/src/lib/descriptors/Geometry/PlaneBufferGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/PlaneBufferGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/PlaneGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/PlaneGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/PolyhedronGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/PolyhedronGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/RingGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/RingGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/ShapeGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/ShapeGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import GeometryWithShapesDescriptor from './GeometryWithShapesDescriptor';
 

--- a/src/lib/descriptors/Geometry/Shapes/HoleDescriptor.js
+++ b/src/lib/descriptors/Geometry/Shapes/HoleDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import invariant from 'fbjs/lib/invariant';
 
 import PathDescriptorBase from './PathDescriptorBase';

--- a/src/lib/descriptors/Geometry/Shapes/PathDescriptorBase.js
+++ b/src/lib/descriptors/Geometry/Shapes/PathDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/lib/descriptors/Geometry/Shapes/ShapeActionDescriptorBase.js
+++ b/src/lib/descriptors/Geometry/Shapes/ShapeActionDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 

--- a/src/lib/descriptors/Geometry/Shapes/ShapeDescriptor.js
+++ b/src/lib/descriptors/Geometry/Shapes/ShapeDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PathDescriptorBase from './PathDescriptorBase';
 import resource from '../../decorators/resource';

--- a/src/lib/descriptors/Geometry/Shapes/SplineThruDescriptor.js
+++ b/src/lib/descriptors/Geometry/Shapes/SplineThruDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/SphereGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/SphereGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import PropTypes from 'react/lib/ReactPropTypes';
 
 import BufferGeometryDescriptorBase from './BufferGeometryDescriptorBase';

--- a/src/lib/descriptors/Geometry/TetrahedronGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/TetrahedronGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PolyhedronGeometryDescriptorBase from './PolyhedronGeometryDescriptorBase';
 

--- a/src/lib/descriptors/Geometry/TextGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/TextGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/TorusGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/TorusGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/TorusKnotGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/TorusKnotGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Geometry/TubeGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/TubeGeometryDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Light/AmbientLightDescriptor.js
+++ b/src/lib/descriptors/Light/AmbientLightDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Light/DirectionalLightDescriptor.js
+++ b/src/lib/descriptors/Light/DirectionalLightDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Light/HemisphereLightDescriptor.js
+++ b/src/lib/descriptors/Light/HemisphereLightDescriptor.js
@@ -1,0 +1,44 @@
+import * as THREE from 'three';
+
+import PropTypes from 'react/lib/ReactPropTypes';
+
+import LightDescriptorBase from './LightDescriptorBase';
+import propTypeInstanceOf from '../../utils/propTypeInstanceOf';
+
+class HemisphereLightDescriptor extends LightDescriptorBase {
+  constructor(react3Instance) {
+    super(react3Instance);
+
+    this.hasColor();
+
+    this.hasProp('groundColor', {
+      type: PropTypes.oneOfType([
+        propTypeInstanceOf(THREE.Color),
+        PropTypes.number,
+        PropTypes.string,
+      ]),
+      update(threeObject, newColor) {
+        threeObject.groundColor.set(newColor);
+      },
+      default: 0xcccccc,
+    });
+
+    this.hasProp('intensity', {
+      type: PropTypes.number,
+      simple: true,
+      default: 1,
+    });
+  }
+
+  construct(props) {
+    const {
+      color,
+      groundColor,
+      intensity,
+    } = props;
+
+    return new THREE.HemisphereLight(color, groundColor, intensity);
+  }
+}
+
+module.exports = HemisphereLightDescriptor;

--- a/src/lib/descriptors/Light/LightDescriptorBase.js
+++ b/src/lib/descriptors/Light/LightDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 import warning from 'fbjs/lib/warning';

--- a/src/lib/descriptors/Light/PointLightDescriptor.js
+++ b/src/lib/descriptors/Light/PointLightDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Light/SpotLightDescriptor.js
+++ b/src/lib/descriptors/Light/SpotLightDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Material/LineBasicMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/LineBasicMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Material/LineDashedMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/LineDashedMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Material/MaterialDescriptorBase.js
+++ b/src/lib/descriptors/Material/MaterialDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/lib/descriptors/Material/MeshBasicMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/MeshBasicMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 

--- a/src/lib/descriptors/Material/MeshDepthMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/MeshDepthMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 

--- a/src/lib/descriptors/Material/MeshLambertMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/MeshLambertMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 

--- a/src/lib/descriptors/Material/MeshNormalMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/MeshNormalMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import MaterialDescriptorBase from './MaterialDescriptorBase';
 

--- a/src/lib/descriptors/Material/MeshPhongMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/MeshPhongMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Material/MeshStandardMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/MeshStandardMaterialDescriptor.js
@@ -1,0 +1,148 @@
+import * as THREE from 'three';
+
+import PropTypes from 'react/lib/ReactPropTypes';
+
+import MaterialDescriptorBase from './MaterialDescriptorBase';
+import propTypeInstanceOf from '../../utils/propTypeInstanceOf';
+
+class MeshStandardMaterialDescriptor extends MaterialDescriptorBase {
+  constructor(react3RendererInstance) {
+    super(react3RendererInstance);
+
+    this.hasColor();
+    this.hasColor('emissive', 0x000000);
+    this.hasWireframe();
+
+    [
+      'roughness',
+      'metalness',
+    ]
+      .forEach(propName => {
+        this.hasProp(propName, {
+          type: PropTypes.number,
+          simple: true,
+          default: 0.5,
+        });
+      });
+
+    [
+      'lightMapIntensity',
+      'aoMapIntensity',
+      'emissiveIntensity',
+      'bumpScale',
+      'displacementScale',
+    ]
+      .forEach(propName => {
+        this.hasProp(propName, {
+          type: PropTypes.number,
+          update(threeObject, propValue) {
+            threeObject[propName] = propValue;
+            threeObject.needsUpdate = true;
+          },
+          default: 1,
+        });
+      });
+
+    [
+      'displacementBias',
+    ]
+      .forEach(propName => {
+        this.hasProp(propName, {
+          type: PropTypes.number,
+          update(threeObject, propValue) {
+            threeObject[propName] = propValue;
+            threeObject.needsUpdate = true;
+          },
+          default: 0,
+        });
+      });
+
+    [
+      'refractionRatio',
+    ]
+      .forEach(propName => {
+        this.hasProp(propName, {
+          type: PropTypes.number,
+          update(threeObject, propValue) {
+            threeObject[propName] = propValue;
+            threeObject.needsUpdate = true;
+          },
+          default: 0.98,
+        });
+      });
+
+    this.hasProp('normalScale', {
+      type: propTypeInstanceOf(THREE.Vector2),
+      update(threeObject, normalScale) {
+        threeObject.normalScale.copy(normalScale);
+        threeObject.needsUpdate = true;
+      },
+      default: new THREE.Vector2(1, 1),
+    });
+
+    this.hasProp('shading', {
+      type: PropTypes.oneOf([THREE.FlatShading, THREE.SmoothShading]),
+      update(threeObject, shading) {
+        threeObject.shading = shading;
+        threeObject.needsUpdate = true;
+      },
+      default: THREE.SmoothShading,
+    });
+
+    [
+      'skinning',
+      'morphTargets',
+      'morphNormals',
+    ].forEach(propName => {
+      this.hasProp(propName, {
+        type: PropTypes.bool,
+        update(threeObject, propValue) {
+          threeObject[propName] = propValue;
+          threeObject.needsUpdate = true;
+        },
+        default: false,
+      });
+    });
+  }
+
+  getMaterialDescription(props) {
+    const materialDescription = super.getMaterialDescription(props);
+
+    [
+      'roughness',
+      'metalness',
+
+      'lightMapIntensity',
+      'aoMapIntensity',
+      'emissiveIntensity',
+      'bumpScale',
+      'displacementScale',
+
+      'displacementBias',
+
+      'refractionRatio',
+
+      'normalScale',
+
+      'shading',
+
+      'skinning',
+      'morphTargets',
+      'morphNormals',
+    ].forEach((propName) => {
+      if (props.hasOwnProperty(propName)) {
+        materialDescription[propName] = props[propName];
+      }
+    });
+
+    return materialDescription;
+  }
+
+  construct(props) {
+    const materialDescription = this.getMaterialDescription(props);
+
+    return new THREE.MeshStandardMaterial(materialDescription);
+  }
+}
+
+module.exports = MeshStandardMaterialDescriptor;

--- a/src/lib/descriptors/Material/PointsMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/PointsMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Material/RawShaderMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/RawShaderMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import ShaderMaterialDescriptor from './ShaderMaterialDescriptor';
 

--- a/src/lib/descriptors/Material/ShaderMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/ShaderMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Material/SpriteMaterialDescriptor.js
+++ b/src/lib/descriptors/Material/SpriteMaterialDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Material/TextureDescriptor.js
+++ b/src/lib/descriptors/Material/TextureDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/lib/descriptors/Material/UniformDescriptor.js
+++ b/src/lib/descriptors/Material/UniformDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/lib/descriptors/Material/UniformsDescriptor.js
+++ b/src/lib/descriptors/Material/UniformsDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 

--- a/src/lib/descriptors/Object/Camera/CameraDescriptorBase.js
+++ b/src/lib/descriptors/Object/Camera/CameraDescriptorBase.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import Object3DDescriptor from '../Object3DDescriptor';
 

--- a/src/lib/descriptors/Object/Camera/CubeCameraDescriptor.js
+++ b/src/lib/descriptors/Object/Camera/CubeCameraDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Object/Camera/OrthographicCameraDescriptor.js
+++ b/src/lib/descriptors/Object/Camera/OrthographicCameraDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Object/Camera/PerspectiveCameraDescriptor.js
+++ b/src/lib/descriptors/Object/Camera/PerspectiveCameraDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Object/GroupDescriptor.js
+++ b/src/lib/descriptors/Object/GroupDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import Object3DDescriptor from './Object3DDescriptor';
 

--- a/src/lib/descriptors/Object/Helper/ArrowHelperDescriptor.js
+++ b/src/lib/descriptors/Object/Helper/ArrowHelperDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Object/Helper/AxisHelperDescriptor.js
+++ b/src/lib/descriptors/Object/Helper/AxisHelperDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import PropTypes from 'react/lib/ReactPropTypes';
 

--- a/src/lib/descriptors/Object/Helper/CameraHelperDescriptor.js
+++ b/src/lib/descriptors/Object/Helper/CameraHelperDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import PropTypes from 'react/lib/ReactPropTypes';
 
 import Object3DDescriptor from '../Object3DDescriptor';

--- a/src/lib/descriptors/Object/Helper/GridHelperDescriptor.js
+++ b/src/lib/descriptors/Object/Helper/GridHelperDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import PropTypes from 'react/lib/ReactPropTypes';
 
 import Object3DDescriptor from '../Object3DDescriptor';

--- a/src/lib/descriptors/Object/LineDescriptor.js
+++ b/src/lib/descriptors/Object/LineDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import MeshDescriptor from './MeshDescriptor';
 

--- a/src/lib/descriptors/Object/LineSegmentsDescriptor.js
+++ b/src/lib/descriptors/Object/LineSegmentsDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import MeshDescriptor from './MeshDescriptor';
 

--- a/src/lib/descriptors/Object/MeshDescriptor.js
+++ b/src/lib/descriptors/Object/MeshDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import invariant from 'fbjs/lib/invariant';
 
 import ResourceReference from '../../Resources/ResourceReference';

--- a/src/lib/descriptors/Object/Object3DDescriptor.js
+++ b/src/lib/descriptors/Object/Object3DDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 import PropTypes from 'react/lib/ReactPropTypes';

--- a/src/lib/descriptors/Object/PointsDescriptor.js
+++ b/src/lib/descriptors/Object/PointsDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import MeshDescriptor from './MeshDescriptor';
 

--- a/src/lib/descriptors/Object/SceneDescriptor.js
+++ b/src/lib/descriptors/Object/SceneDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import Object3DDescriptor from './Object3DDescriptor';
 import propTypeInstanceOf from '../../utils/propTypeInstanceOf';

--- a/src/lib/descriptors/Object/SpriteDescriptor.js
+++ b/src/lib/descriptors/Object/SpriteDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import invariant from 'fbjs/lib/invariant';
 
 import Object3DDescriptor from './Object3DDescriptor';

--- a/src/lib/descriptors/React3Descriptor.js
+++ b/src/lib/descriptors/React3Descriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import PropTypes from 'react/lib/ReactPropTypes';
 
 import warning from 'fbjs/lib/warning';

--- a/src/lib/descriptors/Resource/GeometryResourceDescriptor.js
+++ b/src/lib/descriptors/Resource/GeometryResourceDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import invariant from 'fbjs/lib/invariant';
 
 import ResourceDescriptorBase from './ResourceDescriptorBase';

--- a/src/lib/descriptors/Resource/MaterialResourceDescriptor.js
+++ b/src/lib/descriptors/Resource/MaterialResourceDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import invariant from 'fbjs/lib/invariant';
 
 import ResourceDescriptorBase from './ResourceDescriptorBase';

--- a/src/lib/descriptors/Resource/ResourcesDescriptor.js
+++ b/src/lib/descriptors/Resource/ResourcesDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import invariant from 'fbjs/lib/invariant';
 
 import THREEElementDescriptor from '../THREEElementDescriptor';

--- a/src/lib/descriptors/Resource/ShapeGeometryResourceDescriptor.js
+++ b/src/lib/descriptors/Resource/ShapeGeometryResourceDescriptor.js
@@ -1,5 +1,5 @@
 import PropTypes from 'react/lib/ReactPropTypes';
-import THREE from 'three';
+import * as THREE from 'three';
 
 import GeometryResourceDescriptor from './GeometryResourceDescriptor';
 

--- a/src/lib/descriptors/Resource/ShapeResourceDescriptor.js
+++ b/src/lib/descriptors/Resource/ShapeResourceDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 import invariant from 'fbjs/lib/invariant';
 

--- a/src/lib/descriptors/Resource/TextureResourceDescriptor.js
+++ b/src/lib/descriptors/Resource/TextureResourceDescriptor.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 import invariant from 'fbjs/lib/invariant';
 
 import ResourceDescriptorBase from './ResourceDescriptorBase';

--- a/src/lib/utils/CameraUtils.js
+++ b/src/lib/utils/CameraUtils.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import * as THREE from 'three';
 
 class CameraUtils {
   /**

--- a/tests/src/core/React3/CompositeComponents.jsx
+++ b/tests/src/core/React3/CompositeComponents.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import chai from 'chai';
-import THREE from 'three';
+import * as THREE from 'three';
 import sinon from 'sinon';
 
 const { PropTypes } = React;

--- a/tests/src/core/React3/Updates.jsx
+++ b/tests/src/core/React3/Updates.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import chai from 'chai';
-import THREE from 'three';
+import * as THREE from 'three';
 import sinon from 'sinon';
 import { EventEmitter } from 'events';
 

--- a/tests/src/core/Warnings/ManualRendering.jsx
+++ b/tests/src/core/Warnings/ManualRendering.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import THREE from 'three';
+import * as THREE from 'three';
 import ReactDOM from 'react-dom';
 
 import chai from 'chai';

--- a/tests/src/core/Warnings/PropTypes.jsx
+++ b/tests/src/core/Warnings/PropTypes.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import THREE from 'three';
+import * as THREE from 'three';
 import ReactDOM from 'react-dom';
 
 module.exports = type => {
@@ -27,18 +27,18 @@ module.exports = type => {
       '    in scene\n' +
       '    in react3');
     mockConsole.expectDev('Warning: Failed prop type: Invalid prop `position`' +
-      ' of type `THREE.Vector2`' +
-      ' supplied to `scene`, expected instance of `THREE.Vector3`.\n' +
+      ' of type `Vector2`' +
+      ' supplied to `scene`, expected instance of `Vector3`.\n' +
       '    in scene\n' +
       '    in react3');
     mockConsole.expectDev('Warning: Failed prop type: Invalid prop `rotation`' +
-      ' of type `THREE.Vector3`' +
-      ' supplied to `scene`, expected instance of `THREE.Euler`.\n' +
+      ' of type `Vector3`' +
+      ' supplied to `scene`, expected instance of `Euler`.\n' +
       '    in scene\n' +
       '    in react3');
     mockConsole.expectDev('Warning: Failed prop type: Invalid prop `quaternion`' +
-      ' of type `THREE.Euler`' +
-      ' supplied to `scene`, expected instance of `THREE.Quaternion`.\n' +
+      ' of type `Euler`' +
+      ' supplied to `scene`, expected instance of `Quaternion`.\n' +
       '    in scene\n' +
       '    in react3');
     mockConsole.expectDev('Warning: Failed prop type: Invalid prop `renderOrder` of type `string`' +
@@ -46,7 +46,7 @@ module.exports = type => {
       '    in scene\n' +
       '    in react3');
     mockConsole.expectDev('Warning: Failed prop type: Invalid prop `fog` of type `String`' +
-      ' supplied to `scene`, expected instance of `THREE.Fog`.\n' +
+      ' supplied to `scene`, expected instance of `Fog`.\n' +
       '    in scene\n' +
       '    in react3');
 

--- a/tests/src/descriptors/ArrowHelper.jsx
+++ b/tests/src/descriptors/ArrowHelper.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import THREE from 'three';
+import * as THREE from 'three';
 import ReactDOM from 'react-dom';
 import sinon from 'sinon';
 import chai from 'chai';

--- a/tests/src/descriptors/DirectionalLight.jsx
+++ b/tests/src/descriptors/DirectionalLight.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import chai from 'chai';
 import sinon from 'sinon';
-import THREE from 'three';
+import * as THREE from 'three';
 
 module.exports = type => {
   const { expect } = chai;

--- a/tests/src/descriptors/Shapes.jsx
+++ b/tests/src/descriptors/Shapes.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import THREE from 'three';
+import * as THREE from 'three';
 import ReactDOM from 'react-dom';
 import sinon from 'sinon';
 import chai from 'chai';

--- a/tests/src/descriptors/Texture.jsx
+++ b/tests/src/descriptors/Texture.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import THREE from 'three';
+import * as THREE from 'three';
 import ReactDOM from 'react-dom';
 import assert from 'assert';
 import sinon from 'sinon';

--- a/tests/src/descriptors/common.jsx
+++ b/tests/src/descriptors/common.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import sinon from 'sinon';
-import THREE from 'three';
+import * as THREE from 'three';
 
 import { expect } from 'chai';
 

--- a/tests/src/utils/initContainer.jsx
+++ b/tests/src/utils/initContainer.jsx
@@ -38,7 +38,7 @@ module.exports = (type) => {
   const mockConsole = new MockConsole();
 
   mockConsole.expectThreeLog = () => {
-    mockConsole.expect('THREE.WebGLRenderer	79');
+    mockConsole.expect('THREE.WebGLRenderer	82');
   };
 
   if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
This PR moves toward compatibility with react@>=0.80.0, though some issues still remain. The main problem I'm running into is that for some reason prop type validation fails whenever THREE entities are passed as props (e.g. passing a THREE.Vector3 for position). Despite spending a fair amount of time trying to follow the exact sequence of function calls involved in prop validation, I'm still unable to locate the source of the failure. 

If I understand correctly, THREE entities are validated by looking at the name of the constructor (for example, if we have `var v = new THREE.Vector3()`, then `v.constructor.name === 'Vector3'`). But this appears to be entirely consistent with three@>=0.80.0, leading to very strange validation error messages like `Failed prop type: Invalid prop 'position' of type 'Vector3' supplied to 'perspectiveCamera', expected instance of 'Vector3'.`

Finally, I've added an implementation of THREE.HemisphereLight, though no tests have been written for it yet.