### PR TITLE
Add 'up' property to Object3D

### DIFF
--- a/docs/src/internalComponents/shared/Object3DInfo.js
+++ b/docs/src/internalComponents/shared/Object3DInfo.js
@@ -20,6 +20,7 @@ class Object3DInfo extends DocInfo {
       '> **WARNING**: If you use the same material for multiple objects and some of them' +
       ' receive shadows and some do not, it may cause adverse side effects. In that case,' +
       ' it is recommended to use different materials.',
+      up: 'Up direction for the object',
     };
   }
 }

--- a/src/lib/descriptors/Object/Object3DDescriptor.js
+++ b/src/lib/descriptors/Object/Object3DDescriptor.js
@@ -135,6 +135,12 @@ class Object3DDescriptor extends THREEElementDescriptor {
       },
       default: false,
     });
+
+    this.hasProp('up', {
+      type: propTypeInstanceOf(THREE.Vector3),
+      simple: true,
+      default: new THREE.Vector3(0, 1, 0),
+    });
   }
 
   beginPropertyUpdates(threeObject, nextProps) {


### PR DESCRIPTION
Added the 'up' property to the Object3DDescriptor class to allow setting the 'up' vector for cameras (and other objects), see: https://threejs.org/docs/?q=Cam#Reference/Core/Object3D.up for THREE documentation on the property.

Added a brief item to the documentation for the Object3D class to note the new property being added.