### PR TITLE
🌁 Add FogExp2 prop support to scene

### DIFF
--- a/src/lib/descriptors/Object/SceneDescriptor.js
+++ b/src/lib/descriptors/Object/SceneDescriptor.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import PropTypes from 'react/lib/ReactPropTypes';
 
 import Object3DDescriptor from './Object3DDescriptor';
 import propTypeInstanceOf from '../../utils/propTypeInstanceOf';
@@ -8,7 +9,10 @@ class SceneDescriptor extends Object3DDescriptor {
     super(react3Instance);
 
     this.hasProp('fog', {
-      type: propTypeInstanceOf(THREE.Fog),
+      type: PropTypes.oneOfType([
+        propTypeInstanceOf(THREE.Fog),
+        propTypeInstanceOf(THREE.FogExp2),
+      ]),
       simple: true,
       default: undefined,
     });

--- a/tests/src/core/Warnings/PropTypes.jsx
+++ b/tests/src/core/Warnings/PropTypes.jsx
@@ -45,8 +45,7 @@ module.exports = (type) => {
       ' supplied to `scene`, expected `number`.\n' +
       '    in scene\n' +
       '    in react3');
-    mockConsole.expectDev('Warning: Failed prop type: Invalid prop `fog` of type `String`' +
-      ' supplied to `scene`, expected instance of `Fog`.\n' +
+    mockConsole.expectDev('Warning: Failed prop type: Invalid prop `fog` supplied to `scene`.\n' +
       '    in scene\n' +
       '    in react3');
 

--- a/wiki/scene.md
+++ b/wiki/scene.md
@@ -68,7 +68,9 @@ If this property is set, [`THREE.Object3D#lookAt`](http://threejs.org/docs/#Refe
 **Default**: `false`
 
 ### fog
-``` THREE.Fog ```: The [fog](http://threejs.org/docs/#Reference/Scenes/Scene.fog) variable for the scene.
+``` THREE.Fog ```: [Fog](https://threejs.org/docs/#Reference/Scenes/Fog) define a **linear** fog for the scene.
+
+``` THREE.FogExp2 ```: [FogExp2](https://threejs.org/docs/#Reference/Scenes/FogExp2) define an **exponential** fog for the scene.
 
 ===
 


### PR DESCRIPTION
Fix console error when using `FogExp2` within scene. Closes #143.