### PR TITLE
LoadingManager for texture

### DIFF
--- a/src/lib/descriptors/Material/TextureDescriptor.js
+++ b/src/lib/descriptors/Material/TextureDescriptor.js
@@ -172,13 +172,20 @@ class TextureDescriptor extends THREEElementDescriptor {
       },
       default: THREE.LinearMipMapLinearFilter,
     });
+
+    this.hasProp('loadingManager', {
+      type: PropTypes.objectOf(THREE.LoadingManager),
+      update() {
+          // do nothing because these props are only used for initial loading callbacks
+      },
+      default: undefined,
+    });
   }
 
   construct(props) {
     let result;
-
     if (props.hasOwnProperty('url')) {
-      const textureLoader = new THREE.TextureLoader();
+      const textureLoader = new THREE.TextureLoader(props.loadingManager);
 
       if (props.hasOwnProperty('crossOrigin')) {
         textureLoader.crossOrigin = props.crossOrigin;


### PR DESCRIPTION
This feature adds availability to control process of textures uploading in only one LoadingManager.

```js
let manager = new THREE.LoadingManager();
manager.onProgress = function (url, itemsLoaded, itemsTotal ) {
    console.log( 'Started loading file: ' + url + '.\nLoaded ' + itemsLoaded + ' of ' + itemsTotal + ' files.' );
};
manager.onLoad = function ( url, itemsLoaded, itemsTotal ) {
    console.log( 'Finish loading' );
};
this.loadingManager = manager;

........

<texture url="/texture1.png" loadingManager={ this.loadingManager } />
<texture url="/texture2.png" loadingManager={ this.loadingManager } />
<texture url="/texture3.png" loadingManager={ this.loadingManager } />
```

Console output:
```
Started loading file: /static/images/planets/texture1.png.
Loaded 1 of 3 files.
Started loading file: /static/images/planets/texture2.png.
Loaded 2 of 3 files.
Started loading file: /static/images/planets/texture3.png.
Loaded 3 of 3 files.
Started loading file: /static/images/planets/texture1.png.
Finish loading
```