### PR TITLE
Updated `matrix.copy` to `applyMatrix`

### DIFF
--- a/src/lib/descriptors/Object/Object3DDescriptor.js
+++ b/src/lib/descriptors/Object/Object3DDescriptor.js
@@ -155,7 +155,7 @@ class Object3DDescriptor extends THREEElementDescriptor {
     }
 
     if (props.matrix) {
-      threeObject.matrix.copy(props.matrix);
+      threeObject.applyMatrix(props.matrix);
     } else {
       if (props.position) {
         threeObject.position.copy(props.position);


### PR DESCRIPTION
When trying to pass in a `Matrix4` via the `matrix` prop, it seemed that my `Object3D` wasn't applying it at all. After updating it to use `applyMatrix`, the matrix transformation seemed to work fine.