### PR TITLE
Fixing minFilter not getting set in TextureDescriptor

### DIFF
--- a/src/lib/descriptors/Material/TextureDescriptor.js
+++ b/src/lib/descriptors/Material/TextureDescriptor.js
@@ -164,8 +164,8 @@ class TextureDescriptor extends THREEElementDescriptor {
         THREE.LinearFilter,
         THREE.LinearMipMapNearestFilter,
       ]),
-      update(texture, magFilter) {
-        texture.magFilter = magFilter;
+      update(texture, minFilter) {
+        texture.minFilter = minFilter;
         if (texture.image) {
           texture.needsUpdate = true;
         }
@@ -201,6 +201,9 @@ class TextureDescriptor extends THREEElementDescriptor {
       }
 
       result = textureLoader.load(props.url, onLoad, onProgress, onError);
+      if (props.hasOwnProperty('minFilter')) {
+        result.minFilter = props.minFilter;
+      }
     } else {
       invariant(false, 'The texture needs a url property.');
     }


### PR DESCRIPTION
I'm new to this library and submitting pull requests, but I came across minFilter not being set on <texture>
This seemed to be the easiest way to do it. 