### PR TITLE
ESLint on precommit using Husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "compile": "gulp babel",
     "prepublish": "in-publish && npm test || not-in-publish",
     "test": "gulp test",
-    "precommit": "gulp eslint-before-commit"
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.{js,jsx}": "eslint"
   },
   "author": "Firtina \"toxicFork\" Ozbalikci",
   "keywords": [
@@ -62,6 +65,7 @@
     "karma-spec-reporter": "0.0.30",
     "karma-travis-fold-reporter": "1.0.1",
     "karma-webpack": "2.0.3",
+    "lint-staged": "^3.4.0",
     "mocha": "3.2.0",
     "mocha-loader": "1.1.1",
     "pngjs2": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "compile": "gulp babel",
     "prepublish": "in-publish && npm test || not-in-publish",
-    "test": "gulp test"
+    "test": "gulp test",
+    "precommit": "gulp eslint-before-commit"
   },
   "author": "Firtina \"toxicFork\" Ozbalikci",
   "keywords": [
@@ -44,12 +45,12 @@
     "eslint-plugin-jsx-a11y": "4.0.0",
     "eslint-plugin-react": "6.10.3",
     "estraverse-fb": "1.3.1",
-    "ghooks": "2.0.0",
     "gulp": "gulpjs/gulp#4.0",
     "gulp-babel": "6.1.2",
     "gulp-cached": "^1.1.1",
     "gulp-eslint": "^3.0.1",
     "gulp-util": "3.0.8",
+    "husky": "^0.13.3",
     "in-publish": "^2.0.0",
     "isparta-loader": "2.0.0",
     "karma": "1.6.0",
@@ -90,10 +91,5 @@
   "bugs": {
     "url": "https://github.com/toxicFork/react-three-renderer/issues"
   },
-  "homepage": "https://github.com/toxicFork/react-three-renderer#readme",
-  "config": {
-    "ghooks": {
-      "pre-commit": "gulp eslint-before-commit"
-    }
-  }
+  "homepage": "https://github.com/toxicFork/react-three-renderer#readme"
 }


### PR DESCRIPTION
Related to issue: https://github.com/toxicFork/react-three-renderer/issues/167

Feels slower than the prettier branch (https://github.com/toxicFork/react-three-renderer/pull/169), but I think it's doing more work. This is using the .eslintrc and running eslint directly rather than through gulp.

