### PR TITLE
fixed PropTypes deprecation warning

### DIFF
--- a/src/lib/React3.jsx
+++ b/src/lib/React3.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import PureRenderMixin from 'react/lib/ReactComponentWithPureRenderMixin';
+import PropTypes from 'react/lib/ReactPropTypes';
 import * as THREE from 'three';
 
 import React3Renderer from './React3Renderer';
 import propTypeInstanceOf from './utils/propTypeInstanceOf';
-
-const { PropTypes } = React;
 
 class React3 extends React.Component {
 


### PR DESCRIPTION
This is fixing a deprecation warning about accessing PropTypes via the main React package, as PropTypes have been extracted to a separate package, see release notes: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes