### PR TITLE
Updating install instructions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installation
 ============
 
 ```
-npm install --save react@15.5.3 react-dom@15.5.3 three@0.84.0
+npm install --save react@15.6.1 react-dom@15.6.1 three@0.86.0
 npm install --save react-three-renderer
 ```
 


### PR DESCRIPTION
Currently the README says to use `react` & `react-dom` @15.5.3. When I did a fresh install I encountered the warnings below which cleared up after I installed the correct version of React and ThreeJs.

```
warning "react-three-renderer@3.2.1" has incorrect peer dependency "react@~15.6.1".
warning "react-three-renderer@3.2.1" has incorrect peer dependency "react-dom@~15.6.1".
warning "react-three-renderer@3.2.1" has incorrect peer dependency "three@~0.86.0".
```