### PR TITLE
Replace undefined with null as default for index for BufferGeometry

### DIFF
--- a/src/lib/descriptors/Geometry/BufferGeometryDescriptor.js
+++ b/src/lib/descriptors/Geometry/BufferGeometryDescriptor.js
@@ -50,7 +50,7 @@ class BufferGeometryDescriptor extends GeometryDescriptorBase {
         threeObject.setIndex(attributeValue);
       },
       updateInitial: true,
-      default: undefined,
+      default: null,
     });
   }
 


### PR DESCRIPTION
THREE.js uses an explicit type check for `index` as null in BufferGeometry.  If it's `null`, it'll use a default setting.  However, `undefined` throws an error.